### PR TITLE
vcctl add command for job template

### DIFF
--- a/cmd/cli/jobtemplate.go
+++ b/cmd/cli/jobtemplate.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"volcano.sh/volcano/pkg/cli/job"
+)
+
+func buildJobTemplateCmd() *cobra.Command {
+	jobTemplateCmd := &cobra.Command{
+		Use:   "template",
+		Short: "vcctl command line operation job template",
+	}
+
+	jobTemplateRunCmd := &cobra.Command{
+		Use:   "run",
+		Short: "run job by parameters from the command line",
+		Run: func(cmd *cobra.Command, args []string) {
+			checkError(cmd, job.RunJobTemplate())
+		},
+	}
+	job.InitTemplateRunFlags(jobTemplateRunCmd)
+	jobTemplateCmd.AddCommand(jobTemplateRunCmd)
+
+	jobTemplateGenerateCmd := &cobra.Command{
+		Use:   "generate",
+		Short: "generate jobTemplate by parameters from the command line",
+		Run: func(cmd *cobra.Command, args []string) {
+			checkError(cmd, job.GenerateJobTemplate())
+		},
+	}
+	job.InitTemplateGenerateFlags(jobTemplateGenerateCmd)
+	jobTemplateCmd.AddCommand(jobTemplateGenerateCmd)
+
+	return jobTemplateCmd
+}

--- a/cmd/cli/vcctl.go
+++ b/cmd/cli/vcctl.go
@@ -48,6 +48,7 @@ func main() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	rootCmd.AddCommand(buildJobCmd())
+	rootCmd.AddCommand(buildJobTemplateCmd())
 	rootCmd.AddCommand(buildQueueCmd())
 	rootCmd.AddCommand(versionCommand())
 

--- a/pkg/cli/job/template_generate.go
+++ b/pkg/cli/job/template_generate.go
@@ -1,0 +1,118 @@
+package job
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+	"strings"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type generateTemplateFlags struct {
+	commonFlags
+	FileName     string
+	JobName      string
+	Namespace    string
+	GenerateName string
+}
+
+var generateJobTemplateFlags = &generateTemplateFlags{}
+
+// InitTemplateGenerateFlags init the generate flags.
+func InitTemplateGenerateFlags(cmd *cobra.Command) {
+	initFlags(cmd, &generateJobTemplateFlags.commonFlags)
+
+	cmd.Flags().StringVarP(&generateJobTemplateFlags.FileName, "filename", "f", "", "the yaml file of job")
+	cmd.Flags().StringVarP(&generateJobTemplateFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&generateJobTemplateFlags.JobName, "name", "N", "", "the name of job")
+	cmd.Flags().StringVarP(&generateJobTemplateFlags.GenerateName, "generateName", "g", "", "the name for new job template")
+}
+
+func GenerateJobTemplate() error {
+	config, err := util.BuildConfig(generateJobTemplateFlags.Master, generateJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	if generateJobTemplateFlags.JobName == "" && generateJobTemplateFlags.FileName == "" {
+		err = fmt.Errorf("the filename and job name cannot both be left blank")
+		return err
+	}
+
+	var job *vcbatch.Job
+	if generateJobTemplateFlags.FileName != "" {
+		job, err = readJobFile(generateJobTemplateFlags.FileName)
+		if err != nil {
+			return err
+		}
+	}
+
+	if job == nil {
+		jobClient := versioned.NewForConfigOrDie(config)
+		job, err = jobClient.BatchV1alpha1().Jobs(generateJobTemplateFlags.Namespace).Get(context.TODO(), generateJobTemplateFlags.JobName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("fail to get job <%s/%s>", generateJobTemplateFlags.Namespace, generateJobTemplateFlags.JobName)
+		}
+	}
+
+	unstructuredContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(job)
+	if err != nil {
+		return fmt.Errorf("fail to convert job <%s/%s> for：%v", job.Namespace, job.Name, err)
+	}
+	jobTemplate := &unstructured.Unstructured{Object: unstructuredContent}
+	if generateJobTemplateFlags.GenerateName != "" {
+		jobTemplate.SetName(generateJobTemplateFlags.GenerateName)
+	}
+	jobTemplate.SetKind("JobTemplate")
+	if jobTemplate.GetNamespace() == "" {
+		jobTemplate.SetNamespace("default")
+	}
+	jobTemplate.SetAPIVersion("batch.volcano.sh/v1alpha1")
+	jobTemplate.SetManagedFields(nil)
+	jobTemplate.SetAnnotations(nil)
+	jobTemplate.SetGeneration(1)
+	jobTemplate.SetResourceVersion("")
+	jobTemplate.SetUID("")
+	myDynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	myDynamicResourceClient := myDynamicClient.
+		Resource(schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1alpha1", Resource: "jobtemplates"}).
+		Namespace(jobTemplate.GetNamespace())
+	createdTemplate, err := myDynamicResourceClient.Create(context.TODO(), jobTemplate, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("fail to create jobTemplate <%s/%s> for：%v", jobTemplate.GetNamespace(), jobTemplate.GetName(), err)
+	}
+	fmt.Printf("%s/%s created\n", createdTemplate.GetKind(), createdTemplate.GetName())
+
+	return nil
+}
+
+func readJobFile(filename string) (*vcbatch.Job, error) {
+
+	if !strings.Contains(filename, ".yaml") && !strings.Contains(filename, ".yml") {
+		return nil, fmt.Errorf("only support yaml file")
+	}
+
+	file, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file, err: %v", err)
+	}
+
+	var job vcbatch.Job
+	if err := yaml.Unmarshal(file, &job); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal file, err:  %v", err)
+	}
+
+	return &job, nil
+}

--- a/pkg/cli/job/template_generate_test.go
+++ b/pkg/cli/job/template_generate_test.go
@@ -1,0 +1,100 @@
+package job
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
+)
+
+func TestGenerateJobTemplate(t *testing.T) {
+	response := v1alpha1.Job{}
+	jobTemplate := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "JobTemplate",
+			"apiVersion": "batch.volcano.sh/v1alpha1",
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.String(), "jobtemplates") {
+			val, err := json.Marshal(jobTemplate)
+			if err == nil {
+				w.Write(val)
+			}
+			return
+		}
+		val, err := json.Marshal(response)
+		if err == nil {
+			w.Write(val)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	fileName := "testJob.yaml"
+	val, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+	err = ioutil.WriteFile(fileName, val, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(fileName)
+
+	testCases := []struct {
+		Name        string
+		ExpectValue error
+		FileName    string
+	}{
+		{
+			Name:        "GenerateTemplate",
+			ExpectValue: nil,
+		},
+		{
+			Name:        "GenerateTemplateWithFile",
+			FileName:    fileName,
+			ExpectValue: nil,
+		},
+	}
+
+	for i, testcase := range testCases {
+		generateJobTemplateFlags = &generateTemplateFlags{
+			commonFlags: commonFlags{
+				Master: server.URL,
+			},
+			JobName:   "test",
+			Namespace: "test",
+		}
+		if testcase.FileName != "" {
+			generateJobTemplateFlags.FileName = testcase.FileName
+		}
+
+		err := GenerateJobTemplate()
+		if err != nil {
+			t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, err)
+		}
+	}
+
+}
+
+func TestInitTemplateGenerateFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitTemplateGenerateFlags(&cmd)
+
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag namespace")
+	}
+}

--- a/pkg/cli/job/template_run.go
+++ b/pkg/cli/job/template_run.go
@@ -1,0 +1,125 @@
+package job
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+	"strings"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type runTemplateFlags struct {
+	commonFlags
+	FileName          string
+	TemplateName      string
+	TemplateNamespace string
+	GenerateName      string
+}
+
+const createSourceKey = "volcano.sh/createByJobTemplate"
+
+var launchJobTemplateFlags = &runTemplateFlags{}
+
+// InitTemplateRunFlags init the run flags.
+func InitTemplateRunFlags(cmd *cobra.Command) {
+	initFlags(cmd, &launchJobTemplateFlags.commonFlags)
+
+	cmd.Flags().StringVarP(&launchJobTemplateFlags.FileName, "filename", "f", "", "the yaml file of jobTemplate")
+	cmd.Flags().StringVarP(&launchJobTemplateFlags.TemplateNamespace, "namespace", "n", "default", "the namespace of job template")
+	cmd.Flags().StringVarP(&launchJobTemplateFlags.TemplateName, "name", "N", "", "the name of job template")
+	cmd.Flags().StringVarP(&launchJobTemplateFlags.GenerateName, "generateName", "g", "", "the name for new job")
+}
+
+func RunJobTemplate() error {
+	config, err := util.BuildConfig(launchJobTemplateFlags.Master, launchJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	jobTemplate, err := readTemplateFile(launchJobTemplateFlags.FileName)
+	if err != nil {
+		return err
+	}
+	if jobTemplate == nil {
+		if launchJobTemplateFlags.TemplateName == "" {
+			return fmt.Errorf("the filename and template name cannot both be empty")
+		}
+		myDynamicClient, err := dynamic.NewForConfig(config)
+		if err != nil {
+			return err
+		}
+		myDynamicResourceClient := myDynamicClient.
+			Resource(schema.GroupVersionResource{Group: "batch.volcano.sh", Version: "v1alpha1", Resource: "jobtemplates"}).
+			Namespace(launchJobTemplateFlags.TemplateNamespace)
+		jobTemplate, err = myDynamicResourceClient.Get(context.TODO(), launchJobTemplateFlags.TemplateName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("fail to get unstructed jobTemplate for: %v", err)
+		}
+	}
+	jobTemplate.SetKind("Job")
+	jobTemplate.SetManagedFields(nil)
+	jobTemplate.SetGeneration(1)
+	jobTemplate.SetResourceVersion("")
+	jobTemplate.SetUID("")
+	if jobTemplate.GetNamespace() == "" {
+		jobTemplate.SetNamespace("default")
+	}
+	annotations := jobTemplate.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[createSourceKey] = fmt.Sprintf("%s.%s", jobTemplate.GetNamespace(), jobTemplate.GetName())
+	jobTemplate.SetAnnotations(annotations)
+	var job vcbatch.Job
+	result, err := yaml.Marshal(jobTemplate.Object)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(result, &job); err != nil {
+		return err
+	}
+	if launchJobTemplateFlags.GenerateName != "" {
+		job.Name = launchJobTemplateFlags.GenerateName
+	}
+	jobClient := versioned.NewForConfigOrDie(config)
+	newJob, err := jobClient.BatchV1alpha1().Jobs(launchJobTemplateFlags.TemplateNamespace).Create(context.TODO(), &job, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	if newJob.Spec.Queue == "" {
+		newJob.Spec.Queue = "default"
+	}
+
+	fmt.Printf("run job %v successfully\n", newJob.Name)
+
+	return nil
+}
+
+func readTemplateFile(filename string) (*unstructured.Unstructured, error) {
+	if filename == "" {
+		return nil, nil
+	}
+
+	if !strings.Contains(filename, ".yaml") && !strings.Contains(filename, ".yml") {
+		return nil, fmt.Errorf("only support yaml file")
+	}
+
+	file, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file, err: %v", err)
+	}
+
+	jobTemplate := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal(file, &jobTemplate.Object); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal file, err:  %v", err)
+	}
+
+	return jobTemplate, nil
+}

--- a/pkg/cli/job/template_run_test.go
+++ b/pkg/cli/job/template_run_test.go
@@ -1,0 +1,100 @@
+package job
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
+)
+
+func TestRunJobTemplate(t *testing.T) {
+	response := v1alpha1.Job{}
+	jobTemplate := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "JobTemplate",
+			"apiVersion": "batch.volcano.sh/v1alpha1",
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.String(), "jobtemplates") {
+			val, err := json.Marshal(jobTemplate)
+			if err == nil {
+				w.Write(val)
+			}
+			return
+		}
+		val, err := json.Marshal(response)
+		if err == nil {
+			w.Write(val)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	fileName := "testTemplate.yaml"
+	val, err := json.Marshal(jobTemplate)
+	if err != nil {
+		panic(err)
+	}
+	err = ioutil.WriteFile(fileName, val, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(fileName)
+
+	testCases := []struct {
+		Name        string
+		ExpectValue error
+		FileName    string
+	}{
+		{
+			Name:        "RunJob",
+			ExpectValue: nil,
+		},
+		{
+			Name:        "RunJobWithFile",
+			FileName:    fileName,
+			ExpectValue: nil,
+		},
+	}
+
+	for i, testcase := range testCases {
+		launchJobTemplateFlags = &runTemplateFlags{
+			commonFlags: commonFlags{
+				Master: server.URL,
+			},
+			TemplateName:      "test",
+			TemplateNamespace: "test",
+		}
+		if testcase.FileName != "" {
+			launchJobTemplateFlags.FileName = testcase.FileName
+		}
+
+		err := RunJobTemplate()
+		if err != nil {
+			t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, err)
+		}
+	}
+
+}
+
+func TestInitTemplateRunFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitTemplateRunFlags(&cmd)
+
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag namespace")
+	}
+}

--- a/vendor/k8s.io/client-go/dynamic/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/interface.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface
+}
+
+type ResourceInterface interface {
+	Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+type NamespaceableResourceInterface interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is optional.
+// TODO find a better place to move this for existing callers
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+// TODO find a better place to move this for existing callers
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}

--- a/vendor/k8s.io/client-go/dynamic/scheme.go
+++ b/vendor/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, unstructuredCreater{basicScheme}, unstructuredTyper{basicScheme}, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, unstructuredCreater{basicScheme}, unstructuredTyper{basicScheme}, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return runtime.WithVersionEncoder{
+		Version:     gv,
+		Encoder:     encoder,
+		ObjectTyper: unstructuredTyper{basicScheme},
+	}
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return decoder
+}
+
+type unstructuredCreater struct {
+	nested runtime.ObjectCreater
+}
+
+func (c unstructuredCreater) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	out, err := c.nested.New(kind)
+	if err == nil {
+		return out, nil
+	}
+	out = &unstructured.Unstructured{}
+	out.GetObjectKind().SetGroupVersionKind(kind)
+	return out, nil
+}
+
+type unstructuredTyper struct {
+	nested runtime.ObjectTyper
+}
+
+func (t unstructuredTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	kinds, unversioned, err := t.nested.ObjectKinds(obj)
+	if err == nil {
+		return kinds, unversioned, nil
+	}
+	if _, ok := obj.(runtime.Unstructured); ok && !obj.GetObjectKind().GroupVersionKind().Empty() {
+		return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+	}
+	return nil, false, err
+}
+
+func (t unstructuredTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}

--- a/vendor/k8s.io/client-go/dynamic/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type dynamicClient struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &dynamicClient{}
+
+// ConfigFor returns a copy of the provided config with the
+// appropriate dynamic client defaults set.
+func ConfigFor(inConfig *rest.Config) *rest.Config {
+	config := rest.CopyConfig(inConfig)
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	return config
+}
+
+// NewForConfigOrDie creates a new Interface for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) Interface {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// NewForConfig creates a new dynamic client or returns an error.
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := ConfigFor(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client    *dynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+func (c *dynamicClient) Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	name := ""
+	if len(subresources) > 0 {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name = accessor.GetName()
+		if len(name) == 0 {
+			return nil, fmt.Errorf("name is required")
+		}
+	}
+
+	result := c.client.client.
+		Post().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	name := accessor.GetName()
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	name := accessor.GetName()
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(name), "status")...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name is required")
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Watch(ctx)
+}
+
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}


### PR DESCRIPTION
```shell
Flag:
  -g, --generateName        new name for job or template

  -n, --namespace           the namespace of job or template
  -N, --name                the name of origin job or template

  -f, --filename             the yaml file of  job or jobTemplate

[root@master amd64]# vcctl template run  -N  jt-1  -n default  -g  job-2
run job job-2 successfully
[root@master amd64]#vcctl template generate  -N  job-1  -n default  -g  jt-2
JobTemplate/jt-2 created

[root@master amd64]# vcctl template run -f  jobtemplate.yaml  -g  job-3
run job job-3 successfully
[root@master amd64]# vcctl template generate -f   job.yaml  -g  jt-3
JobTemplate/jt-3 created
```